### PR TITLE
Fix critical database migration logic bug

### DIFF
--- a/Reported/Program.cs
+++ b/Reported/Program.cs
@@ -68,7 +68,7 @@ public static class Program
         await dbContext.Database.EnsureCreatedAsync();
 
         var pendingMigrations = await dbContext.Database.GetPendingMigrationsAsync();
-        if (!pendingMigrations.Any())
+        if (pendingMigrations.Any())
         {
             _logger!.Information("Applying database migrations...");
             await dbContext.Database.MigrateAsync();


### PR DESCRIPTION
## Summary
- Fixes the inverted logic in database migration check
- Migrations now apply when there ARE pending migrations instead of when there are NOT
- Addresses critical bug where schema changes would never be deployed

## Changes Made
- Removed negation operator from pendingMigrations.Any() condition in Program.cs:71
- This ensures migrations run when they are actually needed

## Testing
- Project builds successfully with no warnings or errors
- Logic now correctly applies migrations when pending migrations exist

## Impact
This bug was preventing any database schema updates from being applied, which could cause:
- Runtime errors when code expects newer schema features
- Application failures during deployment
- Data consistency issues

Fixes #13

---
Generated with [Claude Code](https://claude.ai/code)