### PR TITLE
Pin Docker volume name to prevent project-name prefixing

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -135,7 +135,8 @@ services:
       - reported-data:/data
 
 volumes:
-  reported-data: {}
+  reported-data:
+    name: reported-data
 EOF
 
 # Pull and start (first time)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,4 +20,5 @@ services:
       - reported-data:/data
 
 volumes:
-  reported-data: {}
+  reported-data:
+    name: reported-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,5 @@ services:
       - reported-data:/data
 
 volumes:
-  reported-data: {}
+  reported-data:
+    name: reported-data


### PR DESCRIPTION
This ensures the volume is always named 'reported-data' regardless of which directory docker compose is run from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)