### PR TITLE
Fix database initialization crash from EnsureCreated/MigrateAsync conflict

### DIFF
--- a/Reported.Persistence/ReportedDbContext.cs
+++ b/Reported.Persistence/ReportedDbContext.cs
@@ -25,4 +25,47 @@ public sealed class ReportedDbContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
         => modelBuilder.ApplyConfigurationsFromAssembly(typeof(ReportedDbContext).Assembly);
+
+    /// <summary>
+    /// Initializes the database using migrations. Handles the transition from
+    /// legacy databases created with EnsureCreated (which lack migration history)
+    /// by backfilling __EFMigrationsHistory for already-applied migrations.
+    /// </summary>
+    public static async Task InitializeDatabaseAsync()
+    {
+        await using var dbContext = new ReportedDbContext();
+
+        var conn = dbContext.Database.GetDbConnection();
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+
+        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name='__EFMigrationsHistory'";
+        var historyExists = await cmd.ExecuteScalarAsync() != null;
+
+        if (!historyExists)
+        {
+            cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name='UserReport'";
+            var tablesExist = await cmd.ExecuteScalarAsync() != null;
+
+            if (tablesExist)
+            {
+                // Database was created with EnsureCreated — backfill history
+                // so MigrateAsync only applies new migrations.
+                cmd.CommandText = """
+                    CREATE TABLE "__EFMigrationsHistory" (
+                        "MigrationId" TEXT NOT NULL PRIMARY KEY,
+                        "ProductVersion" TEXT NOT NULL
+                    );
+                    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+                    VALUES ('20250316151632_Initial', '9.0.3');
+                    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+                    VALUES ('20250317210437_UpdateTable', '9.0.3');
+                    """;
+                await cmd.ExecuteNonQueryAsync();
+            }
+        }
+
+        await conn.CloseAsync();
+        await dbContext.Database.MigrateAsync();
+    }
 }

--- a/Reported/Program.cs
+++ b/Reported/Program.cs
@@ -71,20 +71,7 @@ public static class Program
 
     private static async Task InitializeDatabase()
     {
-        var dbContext = new ReportedDbContext();
-        await dbContext.Database.EnsureCreatedAsync();
-
-        // var pendingMigrations = await dbContext.Database.GetPendingMigrationsAsync();
-        // if (pendingMigrations.Any())
-        // {
-        //     _logger!.Information("Applying database migrations...");
-        //     await dbContext.Database.MigrateAsync();
-        //     _logger.Information("Migrations applied");
-        // }
-        // else
-        // {
-        //     _logger!.Information("No pending migrations.");
-        // }
+        await ReportedDbContext.InitializeDatabaseAsync();
     }
 
     private static async Task ClientReady()
@@ -205,8 +192,6 @@ public static class Program
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         var user = command.User;
 
-        // Ensure all pending EF Core migrations are applied so the AppealRecord table exists.
-        await dbContext.Database.MigrateAsync();
         var appealRecord = await dbContext.Set<AppealRecord>()
             .FirstOrDefaultAsync(a => a.DiscordId == user.Id);
 


### PR DESCRIPTION
## Summary

Fixes the `SQLite Error 1: 'table "UserReport" already exists'` crash that occurs on every `/appeal-count` (and potentially `/appeal`) command.

**Root cause**: The database was originally created with `EnsureCreatedAsync()`, which builds tables directly without writing to `__EFMigrationsHistory`. When `MigrateAsync()` runs (it was called inline in `HandleAppealCount`), EF Core sees no history and tries to replay all migrations from scratch — including the `Initial` migration that creates `UserReport`.

**Two-part fix**:
1. **`ReportedDbContext.InitializeDatabaseAsync()`** — New static method that detects legacy databases (created with `EnsureCreated`) and backfills `__EFMigrationsHistory` with entries for `Initial` and `UpdateTable` before calling `MigrateAsync()`. This ensures only new migrations (like `AddAppealRecord`) are applied.
2. **Remove stray `MigrateAsync()` from `HandleAppealCount`** — Migrations should only run at startup, not on every command invocation.

## Changes
| File | Change |
|------|--------|
| `Reported.Persistence/ReportedDbContext.cs` | Add `InitializeDatabaseAsync()` with legacy DB transition logic |
| `Reported/Program.cs` | Delegate to `InitializeDatabaseAsync()`, remove inline `MigrateAsync` from handler |

## Test plan
- [ ] Deploy to server with existing database (no `__EFMigrationsHistory` table)
- [ ] Verify bot starts without crash — should log backfill and apply `AddAppealRecord`
- [ ] Run `/appeal-count` — verify it responds without migration errors
- [ ] Run `/appeal` — verify tracking still works
- [ ] Verify fresh database (no existing tables) also works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)