### PR TITLE
Add critical appeal outcomes (5% crit win, 1% crit fail)

### DIFF
--- a/Reported.Tests/Services/AppealServiceTests.cs
+++ b/Reported.Tests/Services/AppealServiceTests.cs
@@ -45,8 +45,8 @@ public sealed class AppealServiceTests
         db.Set<UserReport>().Add(new UserReport(100UL, "User", 200UL, "Reporter", false, "NA"));
         await db.SaveChangesAsync();
 
-        // [49] → loss (49 <= 49)
-        var random = new FakeRandomProvider(49);
+        // [99] → regular loss (53-99 range)
+        var random = new FakeRandomProvider(99);
         var service = new AppealService(db, random);
 
         var result = await service.ProcessAppeal(100UL, "User");
@@ -108,7 +108,7 @@ public sealed class AppealServiceTests
         Assert.Equal(1, result1.Value.AppealAttempts);
 
         // Second appeal: loss (report stands, no penalty)
-        var service2 = new AppealService(db, new FakeRandomProvider(49));
+        var service2 = new AppealService(db, new FakeRandomProvider(99));
         var result2 = await service2.ProcessAppeal(100UL, "User");
         Assert.False(result2.Value.Won);
         Assert.Equal(1, result2.Value.AppealWins);
@@ -163,7 +163,7 @@ public sealed class AppealServiceTests
         db.Set<UserReport>().Add(new UserReport(100UL, "User", 200UL, "Reporter", false, "NA"));
         await db.SaveChangesAsync();
 
-        var service = new AppealService(db, new FakeRandomProvider(49));
+        var service = new AppealService(db, new FakeRandomProvider(99));
         var result = await service.ProcessAppeal(100UL, "User");
 
         Assert.True(result.IsSuccess);
@@ -227,7 +227,7 @@ public sealed class AppealServiceTests
         db.Set<UserReport>().Add(new UserReport(100UL, "User", 200UL, "Reporter", false, "NA"));
         await db.SaveChangesAsync();
 
-        var service = new AppealService(db, new FakeRandomProvider(49));
+        var service = new AppealService(db, new FakeRandomProvider(99));
         var result = await service.ProcessAppeal(100UL, "User");
 
         Assert.True(result.IsSuccess);
@@ -299,6 +299,155 @@ public sealed class AppealServiceTests
         Assert.True(result.IsSuccess);
         Assert.False(result.Value.Won);
         Assert.Equal(AppealRejectionReason.OnlySelfReports, result.Value.RejectionReason);
+    }
+
+    [Fact]
+    public async Task ProcessAppeal_CriticalWin_MarksTwoReportsAppealed()
+    {
+        using var factory = TestDbContextFactory.Create();
+        var db = factory.Context;
+
+        db.Set<UserReport>().Add(new UserReport(100UL, "User", 200UL, "Reporter", false, "NA"));
+        db.Set<UserReport>().Add(new UserReport(100UL, "User", 200UL, "Reporter", false, "VA"));
+        await db.SaveChangesAsync();
+
+        // [0] → critical win (0-4 range)
+        var service = new AppealService(db, new FakeRandomProvider(0));
+        var result = await service.ProcessAppeal(100UL, "User");
+
+        Assert.True(result.IsSuccess);
+        Assert.True(result.Value.Won);
+        Assert.True(result.Value.IsCriticalWin);
+        Assert.False(result.Value.IsCriticalFail);
+        Assert.Equal(2, result.Value.ReportsAppealed);
+        Assert.Equal(1, result.Value.AppealWins);
+        Assert.Equal(1, result.Value.AppealAttempts);
+        Assert.Equal(0, result.Value.PenaltyReportsAdded);
+
+        var reports = await db.Set<UserReport>().ToListAsync();
+        Assert.Equal(2, reports.Count);
+        Assert.All(reports, r => Assert.True(r.HasBeenAppealed));
+    }
+
+    [Fact]
+    public async Task ProcessAppeal_CriticalWin_TargetsAlreadyAppealedReport()
+    {
+        using var factory = TestDbContextFactory.Create();
+        var db = factory.Context;
+
+        // Older report already appealed (denied previously); newer report eligible
+        db.Set<UserReport>().Add(new UserReport(100UL, "User", 200UL, "Reporter", false, "NA", hasBeenAppealed: true));
+        db.Set<UserReport>().Add(new UserReport(100UL, "User", 200UL, "Reporter", false, "VA"));
+        await db.SaveChangesAsync();
+
+        // [4] → still critical win (0-4 range)
+        var service = new AppealService(db, new FakeRandomProvider(4));
+        var result = await service.ProcessAppeal(100UL, "User");
+
+        Assert.True(result.IsSuccess);
+        Assert.True(result.Value.IsCriticalWin);
+        Assert.Equal(2, result.Value.ReportsAppealed);
+
+        var reports = await db.Set<UserReport>().OrderBy(r => r.Id).ToListAsync();
+        Assert.All(reports, r => Assert.True(r.HasBeenAppealed));
+    }
+
+    [Fact]
+    public async Task ProcessAppeal_CriticalWin_OnlyOneReport_DoesNotCrash()
+    {
+        using var factory = TestDbContextFactory.Create();
+        var db = factory.Context;
+
+        db.Set<UserReport>().Add(new UserReport(100UL, "User", 200UL, "Reporter", false, "NA"));
+        await db.SaveChangesAsync();
+
+        var service = new AppealService(db, new FakeRandomProvider(0));
+        var result = await service.ProcessAppeal(100UL, "User");
+
+        Assert.True(result.IsSuccess);
+        Assert.True(result.Value.IsCriticalWin);
+        Assert.Equal(1, result.Value.ReportsAppealed);
+        Assert.Equal(1, result.Value.AppealWins);
+
+        var reports = await db.Set<UserReport>().ToListAsync();
+        Assert.Single(reports);
+        Assert.True(reports[0].HasBeenAppealed);
+    }
+
+    [Fact]
+    public async Task ProcessAppeal_CriticalFail_AddsFiveDuPenaltyReports()
+    {
+        using var factory = TestDbContextFactory.Create();
+        var db = factory.Context;
+
+        db.Set<UserReport>().Add(new UserReport(100UL, "User", 200UL, "Reporter", false, "NA"));
+        await db.SaveChangesAsync();
+
+        // [5] → critical fail
+        var service = new AppealService(db, new FakeRandomProvider(5));
+        var result = await service.ProcessAppeal(100UL, "User");
+
+        Assert.True(result.IsSuccess);
+        Assert.False(result.Value.Won);
+        Assert.True(result.Value.IsCriticalFail);
+        Assert.False(result.Value.IsCriticalWin);
+        Assert.Equal(0, result.Value.AppealWins);
+        Assert.Equal(1, result.Value.AppealAttempts);
+        Assert.Equal(5, result.Value.PenaltyReportsAdded);
+
+        var reports = await db.Set<UserReport>().ToListAsync();
+        Assert.Equal(6, reports.Count);
+
+        var original = reports.Single(r => r.InitiatedUserDiscordId == 200UL);
+        Assert.True(original.HasBeenAppealed);
+
+        var penalties = reports.Where(r => r.InitiatedUserDiscordId == 100UL).ToList();
+        Assert.Equal(5, penalties.Count);
+        Assert.All(penalties, r =>
+        {
+            Assert.Equal("DU", r.Description);
+            Assert.True(r.Confused);
+            Assert.Equal(100UL, r.DiscordId);
+        });
+    }
+
+    [Fact]
+    public async Task ProcessAppeal_RegularWinBoundaries_StillWin()
+    {
+        foreach (var roll in new[] { 6, 30, 52 })
+        {
+            using var factory = TestDbContextFactory.Create();
+            var db = factory.Context;
+
+            db.Set<UserReport>().Add(new UserReport(100UL, "User", 200UL, "Reporter", false, "NA"));
+            await db.SaveChangesAsync();
+
+            var service = new AppealService(db, new FakeRandomProvider(roll));
+            var result = await service.ProcessAppeal(100UL, "User");
+
+            Assert.True(result.Value.Won, $"roll {roll} should be a regular win");
+            Assert.False(result.Value.IsCriticalWin, $"roll {roll} should not be critical");
+        }
+    }
+
+    [Fact]
+    public async Task ProcessAppeal_RegularLossBoundaries_StillLoss()
+    {
+        foreach (var roll in new[] { 53, 75, 99 })
+        {
+            using var factory = TestDbContextFactory.Create();
+            var db = factory.Context;
+
+            db.Set<UserReport>().Add(new UserReport(100UL, "User", 200UL, "Reporter", false, "NA"));
+            await db.SaveChangesAsync();
+
+            var service = new AppealService(db, new FakeRandomProvider(roll));
+            var result = await service.ProcessAppeal(100UL, "User");
+
+            Assert.False(result.Value.Won, $"roll {roll} should be a regular loss");
+            Assert.False(result.Value.IsCriticalFail, $"roll {roll} should not be critical");
+            Assert.Equal(0, result.Value.PenaltyReportsAdded);
+        }
     }
 
     [Fact]

--- a/Reported/Models/AppealOutcome.cs
+++ b/Reported/Models/AppealOutcome.cs
@@ -6,4 +6,7 @@ public sealed record AppealOutcome(
     int AppealAttempts,
     bool HadNoReports,
     int PenaltyReportsAdded,
-    AppealRejectionReason RejectionReason = AppealRejectionReason.None);
+    AppealRejectionReason RejectionReason = AppealRejectionReason.None,
+    bool IsCriticalWin = false,
+    bool IsCriticalFail = false,
+    int ReportsAppealed = 1);

--- a/Reported/Program.cs
+++ b/Reported/Program.cs
@@ -169,6 +169,29 @@ public static class Program
             await command.RespondAsync(
                 $"{user.Mention}, LOL you didn't have any reports to appeal. Here is 10 to get you started");
         }
+        else if (outcome.IsCriticalWin)
+        {
+            _logger!.Information(
+                "Appeal outcome for {DiscordId}: {AppealOutcome}, total wins: {TotalWins}, total attempts: {TotalAttempts}, reports appealed: {ReportsAppealed}",
+                user.Id, "won-critical", outcome.AppealWins, outcome.AppealAttempts, outcome.ReportsAppealed);
+
+            var critMessage = outcome.ReportsAppealed >= 2
+                ? $"{user.Mention}, CRITICAL APPEAL! :sparkles::sparkles: Two reports vanish into the void — appeal approved twice over"
+                : $"{user.Mention}, CRITICAL APPEAL! :sparkles: The judge wanted to wipe two reports but you only had one. Lucky you";
+
+            await command.RespondAsync(critMessage);
+            await command.FollowupAsync(
+                "https://tenor.com/view/tiger-woods-stare-we-can-do-it-gif-11974968");
+        }
+        else if (outcome.IsCriticalFail)
+        {
+            _logger!.Information(
+                "Appeal outcome for {DiscordId}: {AppealOutcome}, total wins: {TotalWins}, total attempts: {TotalAttempts}, penalty: {PenaltyReportsAdded}",
+                user.Id, "lost-critical", outcome.AppealWins, outcome.AppealAttempts, outcome.PenaltyReportsAdded);
+
+            await command.RespondAsync(
+                $"{user.Mention}, CRITICAL FAIL on appeal! :gavel::boom: The judge slammed the gavel and gave you 5 fresh DU reports for wasting their time");
+        }
         else if (outcome.Won)
         {
             _logger!.Information(

--- a/Reported/Services/AppealService.cs
+++ b/Reported/Services/AppealService.cs
@@ -73,7 +73,12 @@ public sealed class AppealService
                     RejectionReason: rejectionReason));
             }
 
-            var coinToss = _random.Next(0, 100);
+            // Roll 0-99:
+            //   0-4   → critical win  (5%)  marks 2 reports appealed (any source, incl. already-appealed)
+            //   5     → critical fail (1%)  consumes the eligible report and adds 5 "DU" reports
+            //   6-52  → regular win   (47%)
+            //   53-99 → regular loss  (47%)
+            var roll = _random.Next(0, 100);
 
             var appealRecord = await _dbContext.Set<AppealRecord>()
                 .FirstOrDefaultAsync(a => a.DiscordId == userDiscordId);
@@ -84,9 +89,65 @@ public sealed class AppealService
                 _dbContext.Set<AppealRecord>().Add(appealRecord);
             }
 
-            if (coinToss > 49)
+            if (roll < 5)
             {
-                // Win — mark the report as appealed (preserve history)
+                // Critical win — mark a second report appealed regardless of prior appeal status
+                appealRecord.AppealWins++;
+                appealRecord.AppealAttempts++;
+                report.HasBeenAppealed = true;
+
+                var secondTarget = await _dbContext.Set<UserReport>()
+                    .OrderBy(r => r.Id)
+                    .FirstOrDefaultAsync(r =>
+                        r.DiscordId == userDiscordId
+                        && r.Id != report.Id
+                        && r.DiscordId != r.InitiatedUserDiscordId);
+
+                if (secondTarget is not null)
+                {
+                    secondTarget.HasBeenAppealed = true;
+                }
+
+                await _dbContext.SaveChangesAsync();
+
+                return Result.Success(new AppealOutcome(
+                    Won: true,
+                    AppealWins: appealRecord.AppealWins,
+                    AppealAttempts: appealRecord.AppealAttempts,
+                    HadNoReports: false,
+                    PenaltyReportsAdded: 0,
+                    IsCriticalWin: true,
+                    ReportsAppealed: secondTarget is not null ? 2 : 1));
+            }
+
+            if (roll == 5)
+            {
+                // Critical fail — eligible report still consumed, plus 5 "DU" penalty reports
+                appealRecord.AppealAttempts++;
+                report.HasBeenAppealed = true;
+
+                for (var i = 0; i < 5; i++)
+                {
+                    _dbContext.Set<UserReport>().Add(new UserReport(
+                        userDiscordId, userName,
+                        userDiscordId, userName,
+                        true, "DU"));
+                }
+
+                await _dbContext.SaveChangesAsync();
+
+                return Result.Success(new AppealOutcome(
+                    Won: false,
+                    AppealWins: appealRecord.AppealWins,
+                    AppealAttempts: appealRecord.AppealAttempts,
+                    HadNoReports: false,
+                    PenaltyReportsAdded: 5,
+                    IsCriticalFail: true));
+            }
+
+            if (roll <= 52)
+            {
+                // Regular win — mark the report as appealed (preserve history)
                 appealRecord.AppealWins++;
                 appealRecord.AppealAttempts++;
                 report.HasBeenAppealed = true;
@@ -99,21 +160,19 @@ public sealed class AppealService
                     HadNoReports: false,
                     PenaltyReportsAdded: 0));
             }
-            else
-            {
-                // Loss — report stands, no penalty added
-                appealRecord.AppealAttempts++;
-                report.HasBeenAppealed = true;
 
-                await _dbContext.SaveChangesAsync();
+            // Regular loss — report stands, no penalty added
+            appealRecord.AppealAttempts++;
+            report.HasBeenAppealed = true;
 
-                return Result.Success(new AppealOutcome(
-                    Won: false,
-                    AppealWins: appealRecord.AppealWins,
-                    AppealAttempts: appealRecord.AppealAttempts,
-                    HadNoReports: false,
-                    PenaltyReportsAdded: 0));
-            }
+            await _dbContext.SaveChangesAsync();
+
+            return Result.Success(new AppealOutcome(
+                Won: false,
+                AppealWins: appealRecord.AppealWins,
+                AppealAttempts: appealRecord.AppealAttempts,
+                HadNoReports: false,
+                PenaltyReportsAdded: 0));
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- Replaces the flat 50/50 appeal coin toss with a four-way outcome rolled from a single `0-99` draw: 5% critical win (marks 2 reports appealed, including ones already denied), 1% critical fail (eligible report consumed + 5 "DU" self-report penalties), and the remaining 94% split ~47/47 between regular win and regular loss.
- Crits sit **after** the existing eligibility gate, so `OnlySelfReports`, `AllAppealed`, and the no-reports backfire paths are untouched. No DB migration needed — `HasBeenAppealed` already exists, and the crit fail just inserts new rows in the same shape as the existing no-reports backfire.
- New Axiom outcome strings `won-critical` / `lost-critical` for clean log queries.

## Probability table

| Roll  | Outcome           | Effect |
|-------|-------------------|--------|
| 0–4   | Critical Win (5%) | Marks 2 reports `HasBeenAppealed = true` (second target bypasses the unappealed filter). 1 win / 1 attempt. |
| 5     | Critical Fail (1%)| Eligible report consumed + 5 "DU" self-reports added. 0 wins / 1 attempt. |
| 6–52  | Regular Win (47%) | Unchanged. |
| 53–99 | Regular Loss (47%)| Unchanged. |

## Files changed
- `Reported/Models/AppealOutcome.cs` — added `IsCriticalWin`, `IsCriticalFail`, `ReportsAppealed` (defaults preserve existing call sites).
- `Reported/Services/AppealService.cs` — replaced 2-way coin toss with 4-way roll; crit-win second-target lookup intentionally omits the `HasBeenAppealed` filter.
- `Reported/Program.cs` — `HandleAppeal` gets two new message branches with distinct Axiom outcome strings.
- `Reported.Tests/Services/AppealServiceTests.cs` — retargeted prior loss rolls from `49` → `99` (49 is now a regular win under the new ranges) and added 5 new tests: crit win, crit win targeting an already-appealed report, crit win with only 1 report, crit fail, plus boundary rolls (6/30/52, 53/75/99).

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet test` — 41/41 passing locally (16 prior appeal tests + 5 new + others)
- [ ] Manual smoke in dev guild after deploy: invoke `/appeal` and verify the two new message strings render
- [ ] Tail Axiom for `won-critical` / `lost-critical` events to confirm the new outcome strings appear in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)